### PR TITLE
[Feature Request] Korean premium consideration

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -12,6 +12,9 @@ password = ""
 	[APIs.Luna.Krw]
         coinone = "https://tb.coinone.co.kr/api/v1/tradehistory/recent/?market=krw&target=luna"
 
+        [APIs.Luna.Usd]
+        binance = "https://api.binance.com/api/v3/ticker/price?symbol=LUNAUSDT"
+
         [APIs.Stables]
         # API key is required
         # https://currencylayer.com/product

--- a/config/config.go
+++ b/config/config.go
@@ -31,6 +31,9 @@ type configType struct {
 			Krw struct {
 				Coinone string `json:"coinone"`
 			}
+			Usd struct {
+				Binance string `json:"binance"`
+			}
 		}
 
 		Stables struct {
@@ -42,8 +45,8 @@ type configType struct {
 		}
 
 		Band struct {
-			Active bool `json:"active"`
-			Band string `json:"band"`
+			Active bool   `json:"active"`
+			Band   string `json:"band"`
 		}
 	}
 	Options struct {

--- a/oracle/service.go
+++ b/oracle/service.go
@@ -5,18 +5,20 @@ import (
 
 	"github.com/tendermint/go-amino"
 
-//	cmn "github.com/tendermint/tendermint/libs/common"
+	//	cmn "github.com/tendermint/tendermint/libs/common"
 	service "github.com/tendermint/tendermint/libs/service"
 
 	"github.com/node-a-team/terra-oracle/price"
 
 	"github.com/cosmos/cosmos-sdk/client/context"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-//	authtxb "github.com/cosmos/cosmos-sdk/x/auth/client/txbuilder"
+
+	//	authtxb "github.com/cosmos/cosmos-sdk/x/auth/client/txbuilder"
 	authtxb "github.com/cosmos/cosmos-sdk/x/auth/types"
 )
 
 const VotePeriod = 5
+
 //const VotePeriod = 5
 
 type OracleService struct {
@@ -24,13 +26,13 @@ type OracleService struct {
 	ps  *price.PriceService
 	cdc *amino.Codec
 
-	passphrase          string
-	txBldr              authtxb.TxBuilder
-	cliCtx              context.CLIContext
-	lunaPrices          map[string]sdk.DecCoin
-	prevoteInited       bool
-//	changeRateSoftLimit float64
-//	changeRateHardLimit float64
+	passphrase    string
+	txBldr        authtxb.TxBuilder
+	cliCtx        context.CLIContext
+	lunaPrices    map[string]sdk.DecCoin
+	prevoteInited bool
+	//	changeRateSoftLimit float64
+	//	changeRateHardLimit float64
 
 	salts         map[string]string
 	preLunaPrices map[string]sdk.DecCoin
@@ -62,7 +64,6 @@ func (os *OracleService) OnStart() error {
 	// Wait a second until price service fetchs price initially
 	time.Sleep(3 * time.Second)
 
-//	go os.txRoutine()
 	go os.txRoutine()
 
 	return nil

--- a/price/band_luna.go
+++ b/price/band_luna.go
@@ -112,8 +112,8 @@ func (ps *PriceService) bandLunaToKrw(logger log.Logger) {
 	for {
 		if !cfg.Config.APIs.Band.Active {
 			logger.Info("Warning APIs.Band.Active is false in Config.toml. Let's exit the bandLunaToKrw().")
-                        break
-                }
+			break
+		}
 
 		func() {
 			defer func() {

--- a/price/lunaToUsd.go
+++ b/price/lunaToUsd.go
@@ -1,0 +1,71 @@
+package price
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/tendermint/tendermint/libs/log"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	cfg "github.com/node-a-team/terra-oracle/config"
+)
+
+// BinancePrice response from binance
+type BinancePrice struct {
+	Symbol string `json:"symbol"`
+	Price  string `json:"price"`
+}
+
+func (ps *PriceService) lunaToUsd(logger log.Logger) {
+	for {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					logger.Error("Unknown error", r)
+				}
+
+				time.Sleep(cfg.Config.Options.Interval * time.Second)
+			}()
+
+			// resp, err := http.Get("https://api.binance.com/api/v3/ticker/price?symbol=LUNAUSDT")
+			resp, err := http.Get(cfg.Config.APIs.Luna.Usd.Binance)
+			if err != nil {
+				logger.Error("Fail to fetch from binance", err.Error())
+				return
+			}
+			defer func() {
+				resp.Body.Close()
+			}()
+			body, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				logger.Error("Fail to read body", err.Error())
+				return
+			}
+
+			bp := BinancePrice{}
+			err = json.Unmarshal(body, &bp)
+			if err != nil {
+				logger.Error("Fail to unmarshal json", err.Error())
+				return
+			}
+
+			price := bp.Price
+
+			timestamp := time.Now().UTC().Unix()
+
+			logger.Info(fmt.Sprintf("Recent luna/usd: %s, timestamp: %d", price, timestamp))
+
+			// amount, ok := sdk.NewIntFromString(recent.Price)
+			decAmount, err := sdk.NewDecFromStr(price)
+			// if !ok {
+			if err != nil {
+				logger.Error("Fail to parse price to Dec")
+			}
+
+			ps.SetPrice("luna/usd", sdk.NewDecCoinFromDec("usd", decAmount), int64(timestamp))
+		}()
+	}
+}

--- a/price/lunaTokrw.go
+++ b/price/lunaTokrw.go
@@ -13,28 +13,18 @@ import (
 	cfg "github.com/node-a-team/terra-oracle/config"
 )
 
-type BinancePrice struct {
-	Symbol	string	`json:"symbol"`
-	Price	string	`json:"price"`
-}
-
-// for Coinone
-/*
+// TradeHistory response from coinone
 type TradeHistory struct {
 	Trades []Trade `json:"trades"`
 }
 
+// Trade response from coinone
 type Trade struct {
 	Timestamp     uint64 `json:"timestamp"`
 	Price         string `json:"price"`
 	Volume        string `json:"volume"`
 	IsSellerMaker bool   `json:"is_seller_maker"`
 }
-*/
-
-
-
-
 
 func (ps *PriceService) lunaToKrw(logger log.Logger) {
 	for {
@@ -47,7 +37,7 @@ func (ps *PriceService) lunaToKrw(logger log.Logger) {
 				time.Sleep(cfg.Config.Options.Interval * time.Second)
 			}()
 
-			// resp, err := http.Get("https://api.binance.com/api/v3/ticker/price?symbol=LUNAUSDT")
+			// resp, err := http.Get("https://tb.coinone.co.kr/api/v1/tradehistory/recent/?market=krw&target=luna")
 			resp, err := http.Get(cfg.Config.APIs.Luna.Krw.Coinone)
 			if err != nil {
 				logger.Error("Fail to fetch from coinone", err.Error())
@@ -56,87 +46,30 @@ func (ps *PriceService) lunaToKrw(logger log.Logger) {
 			defer func() {
 				resp.Body.Close()
 			}()
+
 			body, err := ioutil.ReadAll(resp.Body)
 			if err != nil {
 				logger.Error("Fail to read body", err.Error())
 				return
 			}
 
-			bp := BinancePrice{}
-			err = json.Unmarshal(body, &bp)
+			th := TradeHistory{}
+			err = json.Unmarshal(body, &th)
 			if err != nil {
 				logger.Error("Fail to unmarshal json", err.Error())
 				return
 			}
 
-			price := bp.Price
+			trades := th.Trades
+			recent := trades[len(trades)-1]
+			logger.Info(fmt.Sprintf("Recent luna/krw: %s, timestamp: %d", recent.Price, recent.Timestamp))
 
-
-			timestamp := time.Now().UTC().Unix()
-
-			logger.Info(fmt.Sprintf("Recent luna/krw: %s, timestamp: %d", price, timestamp))
-
-			// amount, ok := sdk.NewIntFromString(recent.Price)
-			decAmount, err := sdk.NewDecFromStr(price)
-			// if !ok {
+			decAmount, err := sdk.NewDecFromStr(recent.Price)
 			if err != nil {
 				logger.Error("Fail to parse price to Dec")
 			}
-			// ps.SetPrice("luna/krw", sdk.NewDecCoinFromCoin(sdk.NewCoin("krw", amount)))
-			ps.SetPrice("luna/krw", sdk.NewDecCoinFromDec("krw", decAmount), int64(timestamp))
+
+			ps.SetPrice("luna/krw", sdk.NewDecCoinFromDec("krw", decAmount), int64(recent.Timestamp))
 		}()
 	}
 }
-
-
-/*
-func (ps *PriceService) coinoneToLuna(logger log.Logger) {
-        for {
-                func() {
-                        defer func() {
-                                if r := recover(); r != nil {
-                                        logger.Error("Unknown error", r)
-                                }
-
-                                time.Sleep(cfg.Config.Options.Interval * time.Second)
-                        }()
-
-                        // resp, err := http.Get("https://tb.coinone.co.kr/api/v1/tradehistory/recent/?market=krw&target=luna")
-                        resp, err := http.Get(cfg.Config.APIs.Luna.Krw.Coinone)
-                        if err != nil {
-                                logger.Error("Fail to fetch from coinone", err.Error())
-                                return
-                        }
-                        defer func() {
-                                resp.Body.Close()
-                        }()
-                        body, err := ioutil.ReadAll(resp.Body)
-                        if err != nil {
-                                logger.Error("Fail to read body", err.Error())
-                                return
-                        }
-
-                        th := TradeHistory{}
-                        err = json.Unmarshal(body, &th)
-                        if err != nil {
-                                logger.Error("Fail to unmarshal json", err.Error())
-                                return
-                        }
-
-                        trades := th.Trades
-                        recent := trades[len(trades)-1]
-                        logger.Info(fmt.Sprintf("Recent luna/krw: %s, timestamp: %d", recent.Price, recent.Timestamp))
-
-                        // amount, ok := sdk.NewIntFromString(recent.Price)
-                        decAmount, err := sdk.NewDecFromStr(recent.Price)
-                        // if !ok {
-                        if err != nil {
-                                logger.Error("Fail to parse price to Dec")
-                        }
-                        // ps.SetPrice("luna/krw", sdk.NewDecCoinFromCoin(sdk.NewCoin("krw", amount)))
-                        ps.SetPrice("luna/krw", sdk.NewDecCoinFromDec("krw", decAmount), int64(recent.Timestamp))
-                }()
-        }
-}
-*/
-

--- a/price/obi.go
+++ b/price/obi.go
@@ -110,7 +110,7 @@ func MustDecode(data []byte, v ...interface{}) {
 	}
 }
 
-// DecodeUnsigned16 decodes the input bytes into `uint8` and returns the remaining bytes.
+// DecodeUnsigned8 decodes the input bytes into `uint8` and returns the remaining bytes.
 func DecodeUnsigned8(data []byte) (uint8, []byte, error) {
 	if len(data) < 1 {
 		return 0, nil, errors.New("obi: out of range")

--- a/price/sdr.go
+++ b/price/sdr.go
@@ -14,7 +14,7 @@ import (
 	cfg "github.com/node-a-team/terra-oracle/config"
 )
 
-func (ps *PriceService) sdrToKrw(logger log.Logger) {
+func (ps *PriceService) sdrToUsd(logger log.Logger) {
 	for {
 		func() {
 			defer func() {
@@ -40,10 +40,10 @@ func (ps *PriceService) sdrToKrw(logger log.Logger) {
 				return
 			}
 
-			re, _ := regexp.Compile("Korean won[\\s]+[0-9.,]+")
+			re, _ := regexp.Compile("U.S. dollar[\\s]+[0-9.,]+")
 			strs := re.FindAllString(string(body), 2)
 			if len(strs) < 2 {
-				logger.Error("Fail to find sdr-won")
+				logger.Error("Fail to find sdr-usd")
 				return
 			}
 			re, _ = regexp.Compile("[0-9.,]+")
@@ -52,14 +52,14 @@ func (ps *PriceService) sdrToKrw(logger log.Logger) {
 
 			timestamp := time.Now().UTC().Unix()
 
-			logger.Info(fmt.Sprintf("Recent sdr/krw: %s, timestamp: %d", price, timestamp))
+			logger.Info(fmt.Sprintf("Recent sdr/usd: %s, timestamp: %d", price, timestamp))
 
 			decAmount, err := sdk.NewDecFromStr(price)
 			if err != nil {
 				logger.Error("Fail to parse price to Dec", err.Error())
 				return
 			}
-			ps.SetPrice("sdr/krw", sdk.NewDecCoinFromDec("krw", decAmount), timestamp)
+			ps.SetPrice("sdr/usd", sdk.NewDecCoinFromDec("usd", decAmount), timestamp)
 		}()
 	}
 }

--- a/price/service.go
+++ b/price/service.go
@@ -32,12 +32,13 @@ func NewPriceService() *PriceService {
 func (ps *PriceService) OnStart() error {
 	// TODO: gracefully quit go routine
 	go ps.lunaToKrw(ps.Logger.With("market", "luna/krw"))
-	go ps.sdrToKrw(ps.Logger.With("market", "sdr/krw"))
-	go ps.stablesToKrw(ps.Logger.With("market", "stables/krw"))
+	go ps.lunaToUsd(ps.Logger.With("market", "luna/usd"))
+	// go ps.sdrToUsd(ps.Logger.With("market", "sdr/usd"))
+	go ps.stablesToUsd(ps.Logger.With("market", "stables/usd"))
 
 	// for Band APIs
 	go ps.bandLunaToKrw(ps.Logger.With("band", "luna/krw"))
-	go ps.fxsToKrw(ps.Logger.With("band", "fxs/krw"))
+	go ps.fxsToUsd(ps.Logger.With("band", "fxs/krw"))
 	return nil
 }
 


### PR DESCRIPTION
Current implementation does not consider the Korean premium for LUNA/KRW, and applies that price when deriving other LUNA / stable coin pairs, leading to large variance in oracle voting. This PR segregates the LUNA/KRW price and uses LUNA/USD for deriving all other stable coin denoms. 

This will prevent the Terra chain from being a source of easy arbitrage for Korean premium through its on-chain swap mechanism once [proposal 27](https://station.terra.money/proposal/27) is passed.